### PR TITLE
Updated Dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 2.4.0 < 4.0.0"
+      "version_requirement": ">= 2.4.0 < 6.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Updated module dependency `version_requirement` for: `puppetlabs/inifile`. Changed dependency maximum version in the `metadata.json` to correct the warnings and invalid module dependencies.
Please note that I used version numbers exceeding the current version of the dependency to account for future module dependency releases.

This is the warning that I get when I run puppet module list.
```
root@servernode:~# puppet module list
Warning: Module 'puppetlabs-inifile' (v4.1.0) fails to meet some dependencies:
  'karmafeast-report_slack' (v1.0.0) requires 'puppetlabs-inifile' (>= 2.4.0 < 4.0.0)

/etc/puppetlabs/code/environments/production/modules
├── puppetlabs-inifile (v4.1.0)  invalid
```

This pull request fixes these warnings. 